### PR TITLE
Create input-group-button.vue

### DIFF
--- a/lib/components/input-group-button.vue
+++ b/lib/components/input-group-button.vue
@@ -1,0 +1,31 @@
+<template>
+    <span class="input-group-button">
+        <slot>
+          <b-button :disabled="disabled" :variant="variant" href="" v-html="text"></b-button>
+        </slot>
+    </span>
+</template>
+
+<script>
+    import bButton from './button.vue';
+
+    export default {
+        components: {
+            bButton
+        },
+        props: {
+            text: {
+                type: String,
+                default: ''
+            },
+            disabled: {
+                type: Boolean,
+                default: false
+            },
+            variant: {
+                type: String,
+                default: null
+            }
+        }
+    };
+</script>


### PR DESCRIPTION
`input-group-button` component for `input-group`

```html
<b-input-group size="lg" state="warning">
  <b-form-input type="text" v-model="value"></b-form-input>
  <b-input-group-button slot="right" text="Save" @click="saveHandler"></b-input-group-addon>
<b-input-group>
```

or 
```html
<b-input-group size="lg" state="warning">
  <template slot="left">
    <b-input-group-addon>$</b-input-group-addon>
  </template>
  <b-form-input type="number" v-model="value"></b-form-input>
  <template slot="right">
    <b-input-group-addon>.00</b-input-group-addon>
    <b-input-group-button slot="right" text="Save" @click="saveHandler"></b-input-group-addon>
  </template>
<b-input-group>
```

Input group dropdown addon:
```html
<b-input-group size="lg" state="warning" left="Name">
  <b-form-input type="text" v-model="value"></b-form-input>
  <b-input-group-button slot="right" >
    <b-dropdown text="Dropdown" class="m-md-2">
      <b-dropdown-item>Action</b-dropdown-item>
      <b-dropdown-item>Another action</b-dropdown-item>
      <b-dropdown-divider></b-dropdown-divider>
      <b-dropdown-item>Something else here...</b-dropdown-item>
    </b-dropdown>
  </b-input-group-button>
<b-input-group>
```

Note that the `b-input-group` state will auto propagate to the button by CSS.