### PR TITLE
Refactored button code for slot

### DIFF
--- a/lib/components/input-group-button.vue
+++ b/lib/components/input-group-button.vue
@@ -1,8 +1,8 @@
 <template>
     <span class="input-group-button">
-        <slot>
-          <b-button :disabled="disabled" :variant="variant" href="" v-html="text"></b-button>
-        </slot>
+        <b-button :disabled="disabled" :variant="variant" href="">
+            <slot></slot>
+        </b-button>
     </span>
 </template>
 
@@ -14,10 +14,6 @@
             bButton
         },
         props: {
-            text: {
-                type: String,
-                default: ''
-            },
             disabled: {
                 type: Boolean,
                 default: false


### PR DESCRIPTION
`input-group-button` component for `input-group`

```html
<b-input-group size="lg" state="warning">
  <b-form-input type="text" v-model="value"></b-form-input>
  <b-input-group-button slot="right" @click="saveHandler">Save</b-input-group-addon>
<b-input-group>
```
or 
```html
<b-input-group size="lg" state="warning">
  <template slot="left">
    <b-input-group-addon>$</b-input-group-addon>
  </template>
  <b-form-input type="number" v-model="value"></b-form-input>
  <template slot="right">
    <b-input-group-addon>.00</b-input-group-addon>
    <b-input-group-button slot="right" @click="saveHandler">Save</b-input-group-addon>
  </template>
<b-input-group>
```

Does not support dropdown buttons. A Separate component will be needed for dropdown support.

Note that the `b-input-group` state will auto propagate to the button by Bootstrap CSS.