### PR TITLE
Add b-button-group-dropdown to component list (#350)

### DIFF
--- a/lib/components/index.js
+++ b/lib/components/index.js
@@ -2,6 +2,7 @@ import bAlert from './alert.vue';
 import bBreadcrumb from './breadcrumb.vue';
 import bButton from './button.vue';
 import bButtonGroup from './button-group.vue';
+import bButtonGroupDropdown from './button-group-dropdown.vue';
 import bInputGroup from './input-group.vue';
 import bInputGroupAddon from './input-group-addon.vue';
 import bInputGroupButton from './input-group-button.vue';
@@ -49,6 +50,7 @@ export {
     bButton,
     bButton as bBtn,
     bButtonGroup,
+    bButtonGroupDropdown,
     bInputGroup,
     bInputGroupAddon,
     bInputGroupButton,


### PR DESCRIPTION
* Resync with master (#9)

* Create form-input-static.vue

New form-static input

* Added form-input-static compoinent

* Refactored static input

Refactored to use the new `<b-form-input-static>` component

* Switch to bFormInputStatic

Updated child component var to bFormInputStatic to follow proper naming conventions

* Removed lazyFormatter from static-input

* Added trailing semi-colon

To make CircleCI happy

* Added missing 'this'

* [nav-item] add dropdown class

* Added <slot> for robustness

* new b-form-input-static component (#292)

* Create form-input-static.vue

New form-static input

* Added form-input-static compoinent

* Refactored static input

Refactored to use the new `<b-form-input-static>` component

* Switch to bFormInputStatic

Updated child component var to bFormInputStatic to follow proper naming conventions

* Removed lazyFormatter from static-input

* Added trailing semi-colon

To make CircleCI happy

* Added missing 'this'

* Added <slot> for robustness

* fixed missing `.vue` extension on import

* Added missing extension on component import (#293)

* Optimized import order in form-input.vue (#294)

* Added missing extension on component import

* Optimized import order

* [button-group-dropdown]

Added missing bButtonGroupDropdown reference to index.js

* Added missing from